### PR TITLE
Fix config example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Here is an example of how to configure this library
       mode: :live,
       domain: "namedb.org",
       api_key: "key-3ax6xnjp29jd6fds4gc373sgvjxteol0",
-      http_opts: %{
+      http_opts: [
         timeout: 5000,
-      }
+      ]
 
 The configs use a library called [Deferred Config](https://hex.pm/packages/deferred_config)
 so that you can use environment variables that will be loaded at runtime, versus
@@ -34,9 +34,9 @@ Here's an example of how to use the system variables
       mode: {:system, "MAILGUN_MODE", :live, {String, :to_atom}},
       domain: {:system, "MAILGUN_DOMAIN", "defaultname.com"} ,
       api_key: {:system, "MAILGUN_API_KEY"},
-      http_opts: %{
+      http_opts: [
         timeout: 5000,
-      }
+      ]
 
 Our default `mix test` tests will use [Bypass](https://hex.pm/packages/bypass)
 as the `base` service URL so that we will not hit your production MailGun


### PR DESCRIPTION
Hi there! It seems that there is a typo in config example. `http_opts` should be a keyword list, not a map.

A map there causes the following error:
```elixir
MailgunEx.send_email([
  from: "me@example.net",
  to: "you@example.net",
  subject: "Test message subject",
  html: "<p>Test message body</p>"
])

** (FunctionClauseError) no function clause matching in Keyword.merge/2

    The following arguments were given to Keyword.merge/2:

        # 1
        %{timeout: 5000}

        # 2
        [params: [from: "me@example.net", to: "you@example.net",
      subject: "Test message subject", text: nil,
      html: "<p>Test message body</p>"]]

    (elixir) lib/keyword.ex:650: Keyword.merge/2
    (mailgun_ex) lib/mailgun_ex/request.ex:53: MailgunEx.Request.create/1
    (mailgun_ex) lib/mailgun_ex/api.ex:44: MailgunEx.Api.request/2
    (mailgun_ex) lib/mailgun_ex/client.ex:154: MailgunEx.Client.send_request/2
```